### PR TITLE
Update attack action param to unit id

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mina-arena-contracts",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "description": "Snarky JS components for Mina Arena",
   "author": "45930",
   "license": "Apache-2.0",

--- a/src/game/GameState.ts
+++ b/src/game/GameState.ts
@@ -1,4 +1,4 @@
-import { Field, Struct, PublicKey, UInt32, Circuit, Poseidon } from 'snarkyjs';
+import { Field, Struct, PublicKey, UInt32, Provable, Poseidon } from 'snarkyjs';
 import { TurnState } from '../turn/TurnState.js';
 
 class NextTurnTuple extends Struct({
@@ -60,7 +60,7 @@ export class GameState extends Struct({
   }
 
   applyTurn(turnState: TurnState): GameState {
-    const nextTurnTuple = Circuit.if(
+    const nextTurnTuple = Provable.if(
       this.playerTurn.equals(Field(1)),
       NextTurnTuple,
       new NextTurnTuple({

--- a/src/objects/AttackDiceRolls.ts
+++ b/src/objects/AttackDiceRolls.ts
@@ -1,5 +1,5 @@
 import {
-  Circuit,
+  Provable,
   Encryption,
   Field,
   Group,
@@ -26,7 +26,7 @@ export class DecrytpedAttackRoll extends Struct({
 
 export class EncrytpedAttackRoll extends Struct({
   publicKey: Group,
-  ciphertext: Circuit.array(Field, 4),
+  ciphertext: Provable.Array(Field, 4),
   signature: Signature,
   rngPublicKey: PublicKey,
 }) {

--- a/src/objects/Position.ts
+++ b/src/objects/Position.ts
@@ -1,4 +1,4 @@
-import { Field, Struct, UInt32, Poseidon, Circuit, Bool } from 'snarkyjs';
+import { Field, Struct, UInt32, Poseidon, Provable, Bool } from 'snarkyjs';
 
 export class Position extends Struct({
   x: UInt32,
@@ -32,12 +32,12 @@ export class Position extends Struct({
      * x, y in our positions are UInt32, but we need to allow negative numbers
      * so the intermediate _x, _y are raw Field values and we will cast the final return to UInt32
      */
-    const _x: Field = Circuit.if(
+    const _x: Field = Provable.if(
       this.x.greaterThanOrEqual(other.x),
       (() => this.x.value.sub(other.x.value))(),
       (() => other.x.value.sub(this.x.value))()
     );
-    const _y: Field = Circuit.if(
+    const _y: Field = Provable.if(
       this.y.greaterThanOrEqual(other.y),
       (() => this.y.value.sub(other.y.value))(),
       (() => other.y.value.sub(this.y.value))()

--- a/src/phase/PhaseState.ts
+++ b/src/phase/PhaseState.ts
@@ -5,7 +5,7 @@ import {
   PublicKey,
   UInt32,
   PrivateKey,
-  Circuit,
+  Provable,
   Bool,
   Poseidon,
 } from 'snarkyjs';
@@ -172,13 +172,13 @@ export class PhaseState extends Struct({
       'Action type must be 1 (ranged attack)'
     ); // action is a "ranged attack" action
     action.actionParams.assertEquals(
-      targetPiece.hash(),
+      targetPiece.id,
       'The action target is different than the proved target piece'
     );
 
     const decrytpedRolls = attackRoll.decryptRoll(serverSecretKey);
     // roll for hit
-    const hit = Circuit.if(
+    const hit = Provable.if(
       decrytpedRolls.hit.greaterThanOrEqual(
         attackingPiece.condition.rangedHitRoll.value
       ),
@@ -187,7 +187,7 @@ export class PhaseState extends Struct({
     );
 
     // roll for wound
-    const wound = Circuit.if(
+    const wound = Provable.if(
       decrytpedRolls.wound.greaterThanOrEqual(
         attackingPiece.condition.rangedWoundRoll.value
       ),
@@ -196,7 +196,7 @@ export class PhaseState extends Struct({
     );
 
     // roll for save
-    const notSave = Circuit.if(
+    const notSave = Provable.if(
       decrytpedRolls.save.greaterThanOrEqual(
         targetPiece.condition.saveRoll.value
       ),
@@ -204,13 +204,13 @@ export class PhaseState extends Struct({
       Bool(true)
     );
 
-    let healthDiff = Circuit.if(
+    let healthDiff = Provable.if(
       Bool.and(Bool.and(hit, wound), notSave),
       attackingPiece.condition.rangedDamage,
       UInt32.from(0)
     );
 
-    const newHealth = Circuit.if(
+    const newHealth = Provable.if(
       healthDiff.greaterThanOrEqual(targetPiece.condition.health),
       UInt32.from(0),
       targetPiece.condition.health.sub(healthDiff)
@@ -275,13 +275,13 @@ export class PhaseState extends Struct({
       'Action type must be 2 (melee attack)'
     ); // action is a "ranged attack" action
     action.actionParams.assertEquals(
-      targetPiece.hash(),
+      targetPiece.id,
       'The action target is different than the proved target piece'
     );
 
     const decrytpedRolls = attackRoll.decryptRoll(serverSecretKey);
     // roll for hit
-    const hit = Circuit.if(
+    const hit = Provable.if(
       decrytpedRolls.hit.greaterThanOrEqual(
         attackingPiece.condition.meleeHitRoll.value
       ),
@@ -290,7 +290,7 @@ export class PhaseState extends Struct({
     );
 
     // roll for wound
-    const wound = Circuit.if(
+    const wound = Provable.if(
       decrytpedRolls.wound.greaterThanOrEqual(
         attackingPiece.condition.meleeWoundRoll.value
       ),
@@ -299,7 +299,7 @@ export class PhaseState extends Struct({
     );
 
     // roll for save
-    const notSave = Circuit.if(
+    const notSave = Provable.if(
       decrytpedRolls.save.greaterThanOrEqual(
         targetPiece.condition.saveRoll.value
       ),
@@ -307,13 +307,13 @@ export class PhaseState extends Struct({
       Bool(true)
     );
 
-    let healthDiff = Circuit.if(
+    let healthDiff = Provable.if(
       Bool.and(Bool.and(hit, wound), notSave),
       attackingPiece.condition.meleeDamage,
       UInt32.from(0)
     );
 
-    const newHealth = Circuit.if(
+    const newHealth = Provable.if(
       healthDiff.greaterThanOrEqual(targetPiece.condition.health),
       UInt32.from(0),
       targetPiece.condition.health.sub(healthDiff)

--- a/tests/non-proof/phase/applyMeleeAtack.test.ts
+++ b/tests/non-proof/phase/applyMeleeAtack.test.ts
@@ -4,7 +4,7 @@ import {
   UInt32,
   Encryption,
   Signature,
-  Circuit,
+  Provable,
 } from 'snarkyjs';
 
 import { PhaseState } from '../../../src/phase/PhaseState';
@@ -131,7 +131,7 @@ describe('PhaseState', () => {
       const piecesTreeBefore = piecesTree.clone();
       const attackDistance = MELEE_ATTACK_RANGE - 5;
 
-      Circuit.runAndCheck(() => {
+      Provable.runAndCheck(() => {
         const newPhaseState = initialPhaseState.applyMeleeAttackAction(
           attack1,
           attack1.sign(player1PrivateKey),
@@ -151,7 +151,7 @@ describe('PhaseState', () => {
           targetAfterAttack.hash()
         );
 
-        Circuit.asProver(() => {
+        Provable.asProver(() => {
           expect(newPhaseState.startingPiecesState.toString()).toBe(
             piecesTreeBefore.tree.getRoot().toString()
           );
@@ -177,7 +177,7 @@ describe('PhaseState', () => {
       const piecesTreeBefore = piecesTree.clone();
       const attackDistance = MELEE_ATTACK_RANGE - 5;
 
-      Circuit.runAndCheck(() => {
+      Provable.runAndCheck(() => {
         const newPhaseState = initialPhaseState.applyMeleeAttackAction(
           attack1,
           attack1.sign(player1PrivateKey),
@@ -197,7 +197,7 @@ describe('PhaseState', () => {
           targetAfterAttack.hash()
         );
 
-        Circuit.asProver(() => {
+        Provable.asProver(() => {
           expect(newPhaseState.startingPiecesState.toString()).toBe(
             piecesTreeBefore.tree.getRoot().toString()
           );
@@ -223,7 +223,7 @@ describe('PhaseState', () => {
       const piecesTreeBefore = piecesTree.clone();
       const attackDistance = MELEE_ATTACK_RANGE - 5;
 
-      Circuit.runAndCheck(() => {
+      Provable.runAndCheck(() => {
         const newPhaseState = initialPhaseState.applyMeleeAttackAction(
           attack1,
           attack1.sign(player1PrivateKey),
@@ -243,7 +243,7 @@ describe('PhaseState', () => {
           targetAfterAttack.hash()
         );
 
-        Circuit.asProver(() => {
+        Provable.asProver(() => {
           expect(newPhaseState.startingPiecesState.toString()).toBe(
             piecesTreeBefore.tree.getRoot().toString()
           );
@@ -269,7 +269,7 @@ describe('PhaseState', () => {
       const attackDistance = MELEE_ATTACK_RANGE + 5;
 
       expect(() => {
-        Circuit.runAndCheck(() => {
+        Provable.runAndCheck(() => {
           initialPhaseState.applyMeleeAttackAction(
             attack2,
             attack2.sign(player1PrivateKey),
@@ -332,7 +332,7 @@ describe('PhaseState', () => {
       const attackDistance = MELEE_ATTACK_RANGE - 5;
 
       expect(() => {
-        Circuit.runAndCheck(() => {
+        Provable.runAndCheck(() => {
           initialPhaseState.applyMeleeAttackAction(
             attack1,
             attack1.sign(player1PrivateKey),

--- a/tests/non-proof/phase/applyMeleeAtack.test.ts
+++ b/tests/non-proof/phase/applyMeleeAtack.test.ts
@@ -105,13 +105,13 @@ describe('PhaseState', () => {
       attack1 = new Action({
         nonce: Field(1),
         actionType: Field(2),
-        actionParams: targetPiece1.hash(),
+        actionParams: targetPiece1.id,
         piece: Field(1),
       });
       attack2 = new Action({
         nonce: Field(1),
         actionType: Field(2),
-        actionParams: targetPiece2.hash(),
+        actionParams: targetPiece2.id,
         piece: Field(1),
       });
     });

--- a/tests/non-proof/phase/applyRangedAttack.test.ts
+++ b/tests/non-proof/phase/applyRangedAttack.test.ts
@@ -4,7 +4,7 @@ import {
   UInt32,
   Encryption,
   Signature,
-  Circuit,
+  Provable,
 } from 'snarkyjs';
 
 import { PhaseState } from '../../../src/phase/PhaseState';
@@ -130,7 +130,7 @@ describe('PhaseState', () => {
       const piecesTreeBefore = piecesTree.clone();
       const attackDistance = 20;
 
-      Circuit.runAndCheck(() => {
+      Provable.runAndCheck(() => {
         const newPhaseState = initialPhaseState.applyRangedAttackAction(
           attack1,
           attack1.sign(player1PrivateKey),
@@ -150,7 +150,7 @@ describe('PhaseState', () => {
           targetAfterAttack.hash()
         );
 
-        Circuit.asProver(() => {
+        Provable.asProver(() => {
           expect(newPhaseState.startingPiecesState.toString()).toBe(
             piecesTreeBefore.tree.getRoot().toString()
           );
@@ -176,7 +176,7 @@ describe('PhaseState', () => {
       const piecesTreeBefore = piecesTree.clone();
       const attackDistance = 20;
 
-      Circuit.runAndCheck(() => {
+      Provable.runAndCheck(() => {
         const newPhaseState = initialPhaseState.applyRangedAttackAction(
           attack1,
           attack1.sign(player1PrivateKey),
@@ -196,7 +196,7 @@ describe('PhaseState', () => {
           targetAfterAttack.hash()
         );
 
-        Circuit.asProver(() => {
+        Provable.asProver(() => {
           expect(newPhaseState.startingPiecesState.toString()).toBe(
             piecesTreeBefore.tree.getRoot().toString()
           );
@@ -222,7 +222,7 @@ describe('PhaseState', () => {
       const piecesTreeBefore = piecesTree.clone();
       const attackDistance = 20;
 
-      Circuit.runAndCheck(() => {
+      Provable.runAndCheck(() => {
         const newPhaseState = initialPhaseState.applyRangedAttackAction(
           attack1,
           attack1.sign(player1PrivateKey),
@@ -242,7 +242,7 @@ describe('PhaseState', () => {
           targetAfterAttack.hash()
         );
 
-        Circuit.asProver(() => {
+        Provable.asProver(() => {
           expect(newPhaseState.startingPiecesState.toString()).toBe(
             piecesTreeBefore.tree.getRoot().toString()
           );
@@ -268,7 +268,7 @@ describe('PhaseState', () => {
       const attackDistance = 100;
 
       expect(() => {
-        Circuit.runAndCheck(() => {
+        Provable.runAndCheck(() => {
           initialPhaseState.applyRangedAttackAction(
             attack2,
             attack2.sign(player1PrivateKey),
@@ -327,7 +327,7 @@ describe('PhaseState', () => {
       const attackDistance = 20;
 
       expect(() => {
-        Circuit.runAndCheck(() => {
+        Provable.runAndCheck(() => {
           initialPhaseState.applyRangedAttackAction(
             attack1,
             attack1.sign(player1PrivateKey),

--- a/tests/non-proof/phase/applyRangedAttack.test.ts
+++ b/tests/non-proof/phase/applyRangedAttack.test.ts
@@ -104,13 +104,13 @@ describe('PhaseState', () => {
       attack1 = new Action({
         nonce: Field(1),
         actionType: Field(1),
-        actionParams: targetPiece1.hash(),
+        actionParams: targetPiece1.id,
         piece: Field(1),
       });
       attack2 = new Action({
         nonce: Field(1),
         actionType: Field(1),
-        actionParams: targetPiece2.hash(),
+        actionParams: targetPiece2.id,
         piece: Field(1),
       });
     });

--- a/tests/proof/PhaseProof.test.ts
+++ b/tests/proof/PhaseProof.test.ts
@@ -2,7 +2,7 @@ import {
   PrivateKey,
   Field,
   UInt32,
-  Circuit,
+  Provable,
   Encryption,
   Signature,
 } from 'snarkyjs';
@@ -154,10 +154,10 @@ describe('PhaseProof', () => {
         playerPublicKey: initialPhaseState.playerPublicKey,
       });
 
-      Circuit.log(
+      Provable.log(
         `initial phase state: ${initialPhaseState.hash().toString()}`
       );
-      Circuit.log(`final phase state: ${finalPhaseState.hash().toString()}`);
+      Provable.log(`final phase state: ${finalPhaseState.hash().toString()}`);
 
       console.time('applyMoveProof');
       const afterMoveProof = await PhaseProgram.applyMove(
@@ -174,14 +174,14 @@ describe('PhaseProof', () => {
       );
       console.timeEnd('applyMoveProof');
 
-      Circuit.log('finished with proof');
-      Circuit.log(
+      Provable.log('finished with proof');
+      Provable.log(
         `Proof state: ${afterMoveProof.publicInput.hash().toString()}`
       );
 
       const didVerify = await afterMoveProof.verify();
 
-      Circuit.log('Verified Proof');
+      Provable.log('Verified Proof');
       expect(true); // did not throw on verify()
       console.timeEnd('applyMove');
     });
@@ -299,10 +299,10 @@ describe('PhaseProof', () => {
         playerPublicKey: initialPhaseState.playerPublicKey,
       });
 
-      Circuit.log(
+      Provable.log(
         `initial phase state: ${initialPhaseState.hash().toString()}`
       );
-      Circuit.log(`final phase state: ${finalPhaseState.hash().toString()}`);
+      Provable.log(`final phase state: ${finalPhaseState.hash().toString()}`);
       console.time('applyRangedAttackProof');
       const afterAttackProof = await PhaseProgram.applyRangedAttack(
         finalPhaseState,
@@ -317,14 +317,14 @@ describe('PhaseProof', () => {
         diceRolls,
         serverPrivateKey
       );
-      Circuit.log('finished with proof');
-      Circuit.log(
+      Provable.log('finished with proof');
+      Provable.log(
         `Proof state: ${afterAttackProof.publicInput.hash().toString()}`
       );
 
       const didVerify = await afterAttackProof.verify();
 
-      Circuit.log('Verified Proof');
+      Provable.log('Verified Proof');
       expect(true); // did not throw on verify()
       console.timeEnd('applyRangedAttack');
     });
@@ -442,10 +442,10 @@ describe('PhaseProof', () => {
         playerPublicKey: initialPhaseState.playerPublicKey,
       });
 
-      Circuit.log(
+      Provable.log(
         `initial phase state: ${initialPhaseState.hash().toString()}`
       );
-      Circuit.log(`final phase state: ${finalPhaseState.hash().toString()}`);
+      Provable.log(`final phase state: ${finalPhaseState.hash().toString()}`);
 
       console.time('applyMeleeAttackProof');
       const afterAttackProof = await PhaseProgram.applyMeleeAttack(
@@ -463,14 +463,14 @@ describe('PhaseProof', () => {
       );
       console.timeEnd('applyMeleeAttackProof');
 
-      Circuit.log('finished with proof');
-      Circuit.log(
+      Provable.log('finished with proof');
+      Provable.log(
         `Proof state: ${afterAttackProof.publicInput.hash().toString()}`
       );
 
       const didVerify = await afterAttackProof.verify();
 
-      Circuit.log('Verified Proof');
+      Provable.log('Verified Proof');
       expect(true); // did not throw on verify()
       console.timeEnd('applyMeleeAttack');
     });


### PR DESCRIPTION
Prime: @louiswheeleriv 

## Context
There is a problem trying to integrate the proof system which goes as follows:

The client is responsible for issuing orders representing the intent of the player.  The server is responsible for storing state and calculating whether the orders with that intent are valid.

Right now, to create an attack action, the client signs a message including the hash of the target of the attack.  That hash is known at the start of the phase, but is liable to be updated throughout the turn.  Once the hash of the target changes (e.g. it is damaged), then the signatures of the other actions are not valid anymore.

## Solution
The design is flawed, and the fix is to allow the client to indicate their intention regardless of how the state has changed.  Ideas like the order of the attacks and the validity of the attack in the state of the world remain unchanged in the proof system.  Now the client indicates their intent soley by including the id of the unit they are attacking, and not adding a precondition relating to the health of that target unit.