### PR TITLE
increasing pieces merkle tree to 32 leaves

### DIFF
--- a/src/objects/PiecesMerkleTree.ts
+++ b/src/objects/PiecesMerkleTree.ts
@@ -1,7 +1,6 @@
 import { Field, MerkleTree, MerkleWitness } from 'snarkyjs';
 
-const MAX_UNITS_PER_SQUAD = 8; // 16 total units
-const TREE_HEIGHT = 5; // 2 ^ 4 = 16
+const TREE_HEIGHT = 6; // 2 ^ 5 = 32
 
 export class PiecesMerkleWitness extends MerkleWitness(TREE_HEIGHT) {}
 

--- a/tests/non-proof/phase/PhaseState.test.ts
+++ b/tests/non-proof/phase/PhaseState.test.ts
@@ -1,4 +1,4 @@
-import { PrivateKey, Field, UInt32 } from 'snarkyjs';
+import { PrivateKey, Field } from 'snarkyjs';
 
 import { PhaseState } from '../../../src/phase/PhaseState';
 import { GameState } from '../../../src/game/GameState';


### PR DESCRIPTION
Making the merkle tree one level taller to allow for up to 32 pieces to join one game